### PR TITLE
Remove inverted and undocumented whitelist.

### DIFF
--- a/run-parts
+++ b/run-parts
@@ -64,10 +64,6 @@ for i in $(LC_ALL=C; echo ${1%/}/*[^~,]) ; do
 	fi
 
 	if [ -e $i ]; then
-		if [ -r $1/whitelist ]; then
-			grep -q "^$(basename $i)$" $1/whitelist && continue
-		fi
-
 		if [ ${list:-0} = 1 ]; then
 			echo $i;
 		elif [ -x $i ]; then


### PR DESCRIPTION
The behavior of whitelist is inverted. Any jobs
present in whitelist are skipped. This is the
exact opposite of the generally accepted meaning
of whitelist.

whitelist is redundant. The current code pattern
and behavior of whitelist exactly duplicate
jobs.deny. If the behavior of whitelist were
flipped and, thereby, aligned with the normal
historical meaning, the code pattern and behavior
would exactly duplicate jobs.allow. In either
case, this feature is redundant.

whitelist is undocumented. Conversely, both
jobs.allow and jobs.deny have been documented for
the recorded lifetime of this git project.

It seems sensible to simply remove this inverted,
undocumented feature.